### PR TITLE
Temp use new rev ai url for gets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Go Rev.ai 
-[![Go Report Card](https://goreportcard.com/badge/github.com/oriiolabs/revai-go)](https://goreportcard.com/report/github.com/oriiolabs/revai-go)
-[![GoDoc](http://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/oriiolabs/revai-go)
+[![Go Report Card](https://goreportcard.com/badge/github.com/descriptinc/revai-go)](https://goreportcard.com/report/github.com/descriptinc/revai-go)
+[![GoDoc](http://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/descriptinc/revai-go)
 
 A [Rev.ai](https://rev.ai) Go client library.
 
@@ -9,20 +9,20 @@ A [Rev.ai](https://rev.ai) Go client library.
 Install revai-go with:
 
 ```sh
-go get -u github.com/oriiolabs/revai-go
+go get -u github.com/descriptinc/revai-go
 ```
 
 Then, import it using:
 
 ``` go
 import (
-    "github.com/oriiolabs/revai-go"
+    "github.com/descriptinc/revai-go"
 )
 ```
 
 ## Documentation
 
-For details on all the functionality in this library, see the [GoDoc](http://godoc.org/github.com/oriiolabs/revai-go)
+For details on all the functionality in this library, see the [GoDoc](http://godoc.org/github.com/descriptinc/revai-go)
 documentation.
 
 Below are a few simple examples:

--- a/examples/streaming/stream.go
+++ b/examples/streaming/stream.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/oriiolabs/revai-go"
+	"github.com/descriptinc/revai-go"
 )
 
 func main() {

--- a/examples/streaming/stream.go
+++ b/examples/streaming/stream.go
@@ -75,4 +75,6 @@ func main() {
 
 	}
 
+	conn.Close()
+
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nicolasgere/revai-go
+module github.com/descriptinc/revai-go
 
 go 1.14
 

--- a/job.go
+++ b/job.go
@@ -127,6 +127,7 @@ type NewURLJobParams struct {
 	CustomVocabularies   []JobOptionCustomVocabulary `json:"custom_vocabularies"`
 	Language             string                      `json:"language"`
 	Transcriber          string                      `json:"transcriber,omitempty"`
+	CustomVocabularyId   string                      `json:"custom_vocabulary_id,omitempty"`
 }
 
 // SubmitURL starts an asynchronous job to transcribe speech-to-text for a media file.

--- a/job.go
+++ b/job.go
@@ -53,6 +53,7 @@ type JobOptions struct {
 	CustomVocabularies   []JobOptionCustomVocabulary `json:"custom_vocabularies,omitempty"`
 	Transcriber          string                      `json:"transcriber,omitempty"`
 	CustomVocabularyId   string                      `json:"custom_vocabulary_id,omitempty"`
+	ForcedAlignment      bool                        `json:"forced_alignment,omitempty"`
 }
 
 type JobOptionCustomVocabulary struct {
@@ -128,6 +129,7 @@ type NewURLJobParams struct {
 	Language             string                      `json:"language"`
 	Transcriber          string                      `json:"transcriber,omitempty"`
 	CustomVocabularyId   string                      `json:"custom_vocabulary_id,omitempty"`
+	ForcedAlignment      bool                        `json:"forced_alignment,omitempty"`
 }
 
 // SubmitURL starts an asynchronous job to transcribe speech-to-text for a media file.

--- a/job.go
+++ b/job.go
@@ -50,7 +50,8 @@ type JobOptions struct {
 	SpeakerChannelsCount int                         `json:"selenaninphe@gmail.com,omitempty"`
 	Metadata             string                      `json:"metadata,omitempty"`
 	CallbackURL          string                      `json:"callback_url,omitempty"`
-	CustomVocabularies   []JobOptionCustomVocabulary `json:"custom_vocabularies"`
+	CustomVocabularies   []JobOptionCustomVocabulary `json:"custom_vocabularies,omitempty"`
+	Transcriber          string                      `json:"transcriber,omitempty"`
 }
 
 type JobOptionCustomVocabulary struct {
@@ -123,7 +124,8 @@ type NewURLJobParams struct {
 	Metadata             string                      `json:"metadata,omitempty"`
 	CallbackURL          string                      `json:"callback_url,omitempty"`
 	CustomVocabularies   []JobOptionCustomVocabulary `json:"custom_vocabularies"`
-	Language string `json:"language"`
+	Language             string                      `json:"language"`
+	Transcriber          string                      `json:"transcriber,omitempty"`
 }
 
 // SubmitURL starts an asynchronous job to transcribe speech-to-text for a media file.

--- a/job.go
+++ b/job.go
@@ -47,7 +47,7 @@ type JobOptions struct {
 	SkipPunctuation      bool                        `json:"skip_punctuation,omitempty"`
 	RemoveDisfluencies   bool                        `json:"remove_disfluencies,omitempty"`
 	FilterProfanity      bool                        `json:"filter_profanity,omitempty"`
-	SpeakerChannelsCount int                         `json:"selenaninphe@gmail.com,omitempty"`
+	SpeakerChannelsCount int                         `json:"speaker_channels_count,omitempty"`
 	Metadata             string                      `json:"metadata,omitempty"`
 	CallbackURL          string                      `json:"callback_url,omitempty"`
 	CustomVocabularies   []JobOptionCustomVocabulary `json:"custom_vocabularies,omitempty"`
@@ -121,7 +121,7 @@ type NewURLJobParams struct {
 	SkipPunctuation      bool                        `json:"skip_punctuation,omitempty"`
 	RemoveDisfluencies   bool                        `json:"remove_disfluencies,omitempty"`
 	FilterProfanity      bool                        `json:"filter_profanity,omitempty"`
-	SpeakerChannelsCount int                         `json:"selenaninphe@gmail.com,omitempty"`
+	SpeakerChannelsCount int                         `json:"speaker_channels_count,omitempty"`
 	Metadata             string                      `json:"metadata,omitempty"`
 	CallbackURL          string                      `json:"callback_url,omitempty"`
 	CustomVocabularies   []JobOptionCustomVocabulary `json:"custom_vocabularies"`

--- a/job.go
+++ b/job.go
@@ -52,6 +52,7 @@ type JobOptions struct {
 	CallbackURL          string                      `json:"callback_url,omitempty"`
 	CustomVocabularies   []JobOptionCustomVocabulary `json:"custom_vocabularies,omitempty"`
 	Transcriber          string                      `json:"transcriber,omitempty"`
+	CustomVocabularyId   string                      `json:"custom_vocabulary_id,omitempty"`
 }
 
 type JobOptionCustomVocabulary struct {

--- a/revai.go
+++ b/revai.go
@@ -115,6 +115,7 @@ func (c *Client) newRequest(method string, path string, body interface{}) (*http
 		}
 	}()
 
+	u := c.BaseURL.ResolveReference(rel)
 	if method == http.MethodGet {
 		v, err := query.Values(body)
 		if err != nil {
@@ -122,9 +123,12 @@ func (c *Client) newRequest(method string, path string, body interface{}) (*http
 		}
 
 		rel.RawQuery = v.Encode()
-	}
 
-	u := c.BaseURL.ResolveReference(rel)
+		// TODO @Sylvie to revert. Temporary hack for rev ai dns switch.
+		// https://linear.app/descript/issue/BCK-2593/switch-rev-endpoint-to-prevent-dns-downtime.
+		newBaseUrl, _ := url.Parse("https://uw2.api.rev.ai")
+		u = newBaseUrl.ResolveReference(rel)
+	}
 
 	req, err := http.NewRequest(method, u.String(), pr)
 	if err != nil {


### PR DESCRIPTION
https://linear.app/descript/issue/BCK-2593/switch-rev-endpoint-to-prevent-dns-downtime

As discussed, modifies the rev ai wrapper to use the new URL for GET calls only